### PR TITLE
添加PTY配置文件和开启SpringBoot配置扫描

### DIFF
--- a/src/main/java/com/jseed/panel/JseedPanelApplication.java
+++ b/src/main/java/com/jseed/panel/JseedPanelApplication.java
@@ -2,8 +2,12 @@ package com.jseed.panel;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties
+@ConfigurationPropertiesScan
 public class JseedPanelApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/jseed/panel/prop/PtyProperties.java
+++ b/src/main/java/com/jseed/panel/prop/PtyProperties.java
@@ -1,0 +1,14 @@
+package com.jseed.panel.prop;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "pty")
+@Component
+@Data
+public class PtyProperties {
+
+    private boolean enable;
+
+}

--- a/src/main/java/com/jseed/panel/socket/WebSocketServer.java
+++ b/src/main/java/com/jseed/panel/socket/WebSocketServer.java
@@ -1,5 +1,6 @@
 package com.jseed.panel.socket;
 
+import com.jseed.panel.prop.PtyProperties;
 import com.pty4j.PtyProcess;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
@@ -27,7 +28,12 @@ public class WebSocketServer {
     private String userId="";
     private final PtyProcess pty;
 
-    public WebSocketServer() throws IOException {
+    public WebSocketServer(PtyProperties ptyProperties) throws IOException {
+
+        if (!ptyProperties.isEnable()){
+            this.pty = null;
+            return;
+        }
 
         // The command to run in a PTY...
         String[] cmd = { "/bin/bash", "-l"};

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ management.auditevents.enabled=false
 server.port=8080
 beetl.suffix=html
 
+#是否开启pty终端
+pty.enable=true


### PR DESCRIPTION
支持关闭PTY（Windows可运行程序）
该功能仅开发测试，不代表会实装